### PR TITLE
Added .Rhistory and big geoJSON to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,12 @@ Thumbs.db
 *.mov
 *.wmv
 
+
+
+### Own ignore rules
+
+# Rhistory-Files
+*.Rhistory
+
+# files to big to handel for gitHub
+portal/test_portal/resources/dvan_layers/dvan_pop_2019.geojson


### PR DESCRIPTION
.Rhistory-files can be ignored for commits. Big geoJSONs can not be published on gitHub. Therefore I added corresponding rules to the .gitignore-file, and pushed it to the origin LayerandLayout-Branch. I would like to merge this to the develop branch.